### PR TITLE
Fix non-copy attribute for NSCopying types that have a mutable subclass

### DIFF
--- a/PGXcodeActionBrowser/Common/XCIDEHelper.h
+++ b/PGXcodeActionBrowser/Common/XCIDEHelper.h
@@ -60,7 +60,7 @@
 @end
 
 @interface IDEStructureNavigator : NSObject
-@property (retain) NSArray *selectedObjects;
+@property (nonatomic, copy) NSArray *selectedObjects;
 @end
 
 @interface IDENavigableItemCoordinator : NSObject

--- a/PGXcodeActionBrowser/Model/Actions/XCCustomAction.h
+++ b/PGXcodeActionBrowser/Model/Actions/XCCustomAction.h
@@ -23,6 +23,6 @@
 @property (nonatomic, strong) NSImage *icon;
 
 @property (nonatomic, strong) id representedObject;
-@property (nonatomic, strong) NSArray *searchQueryMatchRanges; // REVIEW:  this elsewhere
+@property (nonatomic, copy) NSArray *searchQueryMatchRanges; // REVIEW:  this elsewhere
 
 @end

--- a/PGXcodeActionBrowser/Model/XCActionInterface.h
+++ b/PGXcodeActionBrowser/Model/XCActionInterface.h
@@ -24,7 +24,7 @@
 @property (nonatomic, strong) NSImage *icon;
 
 @property (nonatomic, strong) id representedObject;
-@property (nonatomic, strong) NSArray *searchQueryMatchRanges; // REVIEW:  this elsewhere
+@property (nonatomic, copy) NSArray *searchQueryMatchRanges; // REVIEW:  this elsewhere
 
 - (BOOL)executeWithContext:(id<XCIDEContext>)context;
 - (BOOL)executeWithContext:(id<XCIDEContext>)context arguments:(NSArray *)arguments;

--- a/PGXcodeActionBrowser/Model/XCBlockAction.h
+++ b/PGXcodeActionBrowser/Model/XCBlockAction.h
@@ -26,7 +26,7 @@ typedef void(^XCBlockActionHandler)(id<XCIDEContext> context); // context can be
 @property (nonatomic, strong) NSImage *icon;
 
 @property (nonatomic, strong) id representedObject;
-@property (nonatomic, strong) NSArray *searchQueryMatchRanges; // REVIEW:  this elsewhere
+@property (nonatomic, copy) NSArray *searchQueryMatchRanges; // REVIEW:  this elsewhere
 
 - (instancetype)initWithTitle:(NSString *)title
                        action:(XCBlockActionHandler)action;

--- a/PGXcodeActionBrowser/Plugin/XCActionBarConfiguration.h
+++ b/PGXcodeActionBrowser/Plugin/XCActionBarConfiguration.h
@@ -13,9 +13,9 @@
 @protocol XCActionBarConfiguration <NSObject>
 
 // Interim representation while refactoring
-@property (nonatomic, readonly) NSDictionary *shortcuts;
+@property (nonatomic, copy, readonly) NSDictionary *shortcuts;
 
-@property (nonatomic, readonly) NSArray *supportedTerminalApplications;
+@property (nonatomic, copy, readonly) NSArray *supportedTerminalApplications;
 
 ////////////////////////////////////////////////////////////////////////////////
 // User Alerts
@@ -31,9 +31,9 @@
 ////////////////////////////////////////////////////////////////////////////////
 @interface XCActionBarConfiguration : NSObject <XCActionBarConfiguration>
 
-@property (nonatomic) NSDictionary *shortcuts;
+@property (nonatomic, copy) NSDictionary *shortcuts;
 
-@property (nonatomic) NSArray *supportedTerminalApplications;
+@property (nonatomic, copy) NSArray *supportedTerminalApplications;
 
 ////////////////////////////////////////////////////////////////////////////////
 // User Alerts


### PR DESCRIPTION
`NSCopying` class types that also have a mutable subclass variant (for example `NSString`, `NSArray`) should always be specified as `copy`.

This helps avoid situations where the value of a property could change without the setter being invoked (i.e. the object gets mutated).
