### PR TITLE
Remove restricted method call

### DIFF
--- a/PGXcodeActionBrowser/XCActionBar.m
+++ b/PGXcodeActionBrowser/XCActionBar.m
@@ -131,7 +131,6 @@ static XCActionBar *sharedPlugin;
     [self updateContext];
     [self centerWindowInScreen:[self.windowController window]];
     [self.windowController showWindow:self];
-    [self.windowController becomeFirstResponder];
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- From the documentation:
  
  Use the NSWindow makeFirstResponder: method, not this method, to make an object the first responder. Never invoke this method directly.
- I don't think this method call was ever needed, as in the `XCActionBarWindowController`'s `windowDidBecomeKey:` method correctly calls `[self.window makeFirstResponder:self.searchField];` anyway.
